### PR TITLE
Proper Exception error messages returned instead of std::exception

### DIFF
--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -27,7 +27,7 @@
     } catch(pdftron::Common::Exception& e) {
         SWIG_exception(SWIG_RuntimeError, e.what());
     } catch(std::exception& e) {
-        SWIG_exception(SWIG_RuntimeError, e.what());
+        SWIG_exception(SWIG_RuntimeError, e.GetMessage());
     } catch(...) {
         SWIG_exception(SWIG_RuntimeError, "Unknown error");
     }


### PR DESCRIPTION
Proper Exception error messages returned instead of `std::exception`.