### PR TITLE
Backout changes to Python wrapper after 10.0

### DIFF
--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -228,7 +228,7 @@
 	
     // header files in /PDFNetC/Headers/Layout
     #include "Layout/FlowDocument.h"
-    #include "Layout/ContentTree.h"
+    #include "Layout/Paragraph.h"
     
     using namespace pdftron;
     using namespace FDF;
@@ -696,7 +696,6 @@ namespace pdftron {
 %template (FieldIterator) pdftron::Common::Iterator<pdftron::PDF::Field>;
 %template (CharIterator) pdftron::Common::Iterator<TRN_CharData>;
 %template (DigitalSignatureFieldIterator) pdftron::Common::Iterator<pdftron::PDF::DigitalSignatureField>;
-%template (ContentNodeIterator) pdftron::Common::Iterator<pdftron::Layout::ContentElement>; 
 
 //----------------------------------------------------------------------------------------------
 
@@ -850,7 +849,7 @@ namespace pdftron {
 %include "PDF/PDFDraw.h"
 %include "PDF/WebFontDownloader.h"
 
-%include "Layout/ContentTree.h"
+%include "Layout/Paragraph.h"
 %include "Layout/FlowDocument.h"
 
 //Extend Initialize method to call overloaded one internally

--- a/Samples/DocumentCreationTest/PYTHON/DocumentCreationTest.py
+++ b/Samples/DocumentCreationTest/PYTHON/DocumentCreationTest.py
@@ -16,29 +16,6 @@ from LicenseKey import *
 # Relative path to the folder containing the test files.
 outputPath = "../../TestFiles/Output/"
 
-# Iterate over all text runs of the document and make every second run
-# bold with smaller font size.
-def ModifyContentTree(node):
-    bold = False
-
-    itr = node.GetContentNodeIterator()
-
-    while itr.HasNext():
-        el = itr.Current()
-        maybe_content_node = el.AsContentNode()
-        if maybe_content_node.IsValid():
-            ModifyContentTree(maybe_content_node.GetContentNode())
-        else:
-            maybe_text_run = el.AsTextRun()
-            if maybe_text_run.IsValid():
-                if bold:
-                    text_run = maybe_text_run.GetTextRun()
-                    text_run.GetTextStyledElement().SetBold(True)
-                    text_run.GetTextStyledElement().SetFontSize(text_run.GetTextStyledElement().GetFontSize() * 0.8)
-                bold = not bold
-        
-        itr.Next()
-
 def main():
     # The first step in every application using PDFNet is to initialize the 
     # library. The library is usually initialized only once, but calling 
@@ -63,44 +40,10 @@ def main():
     try:
         flowdoc = FlowDocument()
         para = flowdoc.AddParagraph()
-        st_para = para.GetTextStyledElement()
         
-        st_para.SetFontSize(24)
-        st_para.SetTextColor(255, 0, 0)
+        para.SetFontSize(24)
+        para.SetTextColor(255, 0, 0)
         para.AddText("Start Red Text\n")
-        st_para.SetTextColor(0, 0, 255)
-        para.AddText("Start Blue Text\n")
-
-        last_run = para.AddText("Start Green Text\n")
-
-        itr = para.GetContentNodeIterator()
-        i = 0
-        while itr.HasNext():
-            el = itr.Current()
-
-            maybe_text_run = el.AsTextRun()
-            if maybe_text_run.IsValid():
-                run = maybe_text_run.GetTextRun()
-                run.GetTextStyledElement().SetFontSize(12)
-
-                if i == 0:
-                    # restore red color
-                    run.SetText(run.GetText() + "(restored red color)\n")
-                    run.GetTextStyledElement().SetTextColor(255, 0, 0)
-
-            itr.Next()
-            i += 1
-
-        st_last = last_run.GetTextStyledElement()
-
-        st_last.SetTextColor(0, 255, 0)
-        st_last.SetItalic(True)
-        st_last.SetFontSize(18)
-
-        para.GetTextStyledElement().SetBold(True)
-
-        st_last.SetBold(False)
-
         flowdoc.SetDefaultMargins(0, 72.0, 144.0, 228.0)
         flowdoc.SetDefaultPageSize(650, 750)
         flowdoc.AddParagraph(para_text)
@@ -110,26 +53,19 @@ def main():
 
         for i in range(50):
             para = flowdoc.AddParagraph()
-            st = para.GetTextStyledElement()
-
             point_size = (17*i*i*i)%13+5
             if i % 2 == 0:
-                st.SetItalic(True)
-                st.SetTextColor(clr1[0], clr1[1], clr1[2])
+                para.SetItalic(True)
+                para.SetTextColor(clr1[0], clr1[1], clr1[2])
                 para.SetSpaceBefore(20)
                 para.SetJustificationMode(ParagraphStyle.e_text_justify_left)
             else:
-                st.SetTextColor(clr2[0], clr2[1], clr2[2])
+                para.SetTextColor(clr2[0], clr2[1], clr2[2])
                 para.SetSpaceBefore(50)
                 para.SetJustificationMode(ParagraphStyle.e_text_justify_right)
 
             para.AddText(para_text)
-            para.AddText(" " + para_text)
-            st.SetFontSize(point_size)
-
-        # Walk the content tree and modify some text runs.
-        body = flowdoc.GetBody()
-        ModifyContentTree(body)
+            para.SetFontSize(point_size)
 
         my_pdf = flowdoc.PaginateToPDF()
         my_pdf.Save(outputPath + "created_doc.pdf", SDFDoc.e_linearized)


### PR DESCRIPTION
The changes for the content tree interface of the Document Creation API have been backed out from the master branch in the PDFTronCore repository as they need to be kept out from the upcoming release.

The Python wrapper is now at the state of release 10.0 again with respect to the Document Creation API.