### PR TITLE
Fixed compiler error: imported and not used: "strconv"

### DIFF
--- a/Samples/HTML2PDFTest/GO/HTML2PDF_test.go
+++ b/Samples/HTML2PDFTest/GO/HTML2PDF_test.go
@@ -7,7 +7,6 @@ package HTML2PDFTest
 import (
     "fmt"
     "testing"
-    "strconv"
     . "github.com/pdftron/pdftron-go/v2"
     "flag"
 )


### PR DESCRIPTION
We don't use strconv.Itoa() anymore, so we must not import strconv