### PR TITLE
[Go] Add nil binding for FindObj.

### DIFF
--- a/PDFTronGo/pdftron.i
+++ b/PDFTronGo/pdftron.i
@@ -204,6 +204,16 @@
     }
 }
 
+%typemap(goout) pdftron::SDF::Obj
+%{
+    if swig_r.GetMp_obj().Swigcptr() == 0 {
+        $result = $1
+        return $result
+    }
+
+    $result = nil
+%}
+
 /**
  * Provides mapping for C++ vectors.
  * For example, vector<double> will be called as VectorDouble in GoLang.

--- a/PDFTronGo/pdftron.i
+++ b/PDFTronGo/pdftron.i
@@ -206,7 +206,8 @@
 
 %typemap(goout) pdftron::SDF::Obj
 %{
-    if swig_r.GetMp_obj().Swigcptr() == 0 {
+    // Without the brackets, swig attempts to turn $1 into a c++ dereference.. seems like a bug
+    if ($1).GetMp_obj().Swigcptr() != 0 {
         $result = $1
         return $result
     }

--- a/Samples/InteractiveFormsTest/GO/InteractiveForms_test.go
+++ b/Samples/InteractiveFormsTest/GO/InteractiveForms_test.go
@@ -278,7 +278,7 @@ func TestInteractiveForms(t *testing.T){
 		}else if (fieldType == FieldE_text){
             os.Stdout.Write([]byte("Text" + "\n"))
             // Edit all variable text in the document
-            if itr.Current().GetValue().GetMp_obj().Swigcptr() != 0 {
+            if itr.Current().GetValue() != nil {
                 old_value := itr.Current().GetValueAsString();
                 itr.Current().SetValue("This is a new value. The old one was: " + old_value)
 			}

--- a/Samples/PDFLayersTest/GO/PDFLayers_test.go
+++ b/Samples/PDFLayersTest/GO/PDFLayers_test.go
@@ -58,7 +58,7 @@ func CreateLayer(doc PDFDoc, layerName string) Group{
     }   
     // Add the new OCG to the list of layers that should appear in PDF viewer GUI.
     layerOrderArray := cfg.GetOrder()
-    if layerOrderArray.GetMp_obj().Swigcptr() == 0{
+    if layerOrderArray == nil {
         layerOrderArray = doc.CreateIndirectArray()
         cfg.SetOrder(layerOrderArray)
     }

--- a/Samples/PDFPackageTest/GO/PDFPackage_test.go
+++ b/Samples/PDFPackageTest/GO/PDFPackage_test.go
@@ -36,7 +36,7 @@ func AddPackage(doc PDFDoc, file string, desc string){
     }
     files.Put(&key[0], len(key), fs.GetSDFObj())
     fs.SetDesc(desc)
-
+    
     collection := doc.GetRoot().FindObj("Collection")
     if collection == nil {
         collection = doc.GetRoot().PutDict("Collection")

--- a/Samples/PDFPackageTest/GO/PDFPackage_test.go
+++ b/Samples/PDFPackageTest/GO/PDFPackage_test.go
@@ -36,9 +36,9 @@ func AddPackage(doc PDFDoc, file string, desc string){
     }
     files.Put(&key[0], len(key), fs.GetSDFObj())
     fs.SetDesc(desc)
-    
+
     collection := doc.GetRoot().FindObj("Collection")
-    if collection.GetMp_obj().Swigcptr() == 0{
+    if collection == nil {
         collection = doc.GetRoot().PutDict("Collection")
     }
 


### PR DESCRIPTION
Allows

```   
if collection.GetMp_obj().Swigcptr() == 0 {
  collection = doc.GetRoot().PutDict("Collection")
}
```
To be checked with a nil

```
if collection == nil {
  collection = doc.GetRoot().PutDict("Collection")
}
```