### PR TITLE
[Build] Add support for python 3.12 wrapper

### DIFF
--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -342,10 +342,6 @@ namespace pdftron {
             else if (kind == PyUnicode_4BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_4BYTE_DATA(PyList_GetItem($input, i));
             }
-            else {
-                //for 3.11 and under since its deprecated
-                arr[i] = (char*)PyUnicode_AS_DATA(PyList_GetItem($input, i));
-            }
         }
     #endif
         else {
@@ -478,10 +474,7 @@ namespace pdftron {
             else if (kind == (int)PyUnicode_4BYTE_KIND) {
                 char* $temp1 = (char*)PyUnicode_4BYTE_DATA($str);
             }
-            else {
-                //for 3.11 and under since its deprecated
-                char* $temp1 = (char*)PyUnicode_AS_DATA($str);
-            }
+
             $temp[i] = (pdftron::Unicode)*$temp1;
         }
         else {

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -463,7 +463,7 @@ namespace pdftron {
                 PyErr_SetString(PyExc_ValueError,"Only one character allowed per list item");
                 return NULL;
             }
-            int kind = PyUnicode_KIND(PyList_GetItem($input, i))
+            int kind = PyUnicode_KIND(PyList_GetItem($input, i));
             char* $temp1 = 0;
             if (kind == (int)PyUnicode_1BYTE_KIND) {
                 char* $temp1 = (char*)PyUnicode_1BYTE_DATA($str);

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -332,7 +332,7 @@ namespace pdftron {
     #endif
     #ifdef PYTHON3 
         if (PyUnicode_Check(PyList_GetItem($input, i))) {
-            int kind = PyUnicode_KIND(PyList_GetItem($input, i))
+            int kind = PyUnicode_KIND(PyList_GetItem($input, i));
             if (kind == PyUnicode_1BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_1BYTE_DATA(PyList_GetItem($input, i));
             }

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -333,7 +333,7 @@ namespace pdftron {
     #ifdef PYTHON3 
         if (PyUnicode_Check(PyList_GetItem($input, i))) {
             int kind = PyUnicode_KIND(PyList_GetItem($input, i));
-            if (kind == (int)(PyUnicode_1BYTE_KIND) {
+            if (kind == (int)PyUnicode_1BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_1BYTE_DATA(PyList_GetItem($input, i));
             }
             else if (kind == (int)PyUnicode_2BYTE_KIND) {

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -333,13 +333,13 @@ namespace pdftron {
     #ifdef PYTHON3 
         if (PyUnicode_Check(PyList_GetItem($input, i))) {
             int kind = PyUnicode_KIND(PyList_GetItem($input, i));
-            if (kind == PyUnicode_1BYTE_KIND) {
+            if (kind == (int)(PyUnicode_1BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_1BYTE_DATA(PyList_GetItem($input, i));
             }
-            else if (kind == PyUnicode_2BYTE_KIND) {
+            else if (kind == (int)PyUnicode_2BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_2BYTE_DATA(PyList_GetItem($input, i));
             }
-            else if (kind == PyUnicode_4BYTE_KIND) {
+            else if (kind == (int)PyUnicode_4BYTE_KIND) {
                 arr[i] = (char*)PyUnicode_4BYTE_DATA(PyList_GetItem($input, i));
             }
         }

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -332,7 +332,20 @@ namespace pdftron {
     #endif
     #ifdef PYTHON3 
         if (PyUnicode_Check(PyList_GetItem($input, i))) {
-            arr[i] = (char*)PyUnicode_AS_DATA(PyList_GetItem($input, i));
+            int kind = PyUnicode_KIND(PyList_GetItem($input, i))
+            if (kind == PyUnicode_1BYTE_KIND) {
+                arr[i] = (char*)PyUnicode_1BYTE_DATA(PyList_GetItem($input, i));
+            }
+            else if (kind == PyUnicode_2BYTE_KIND) {
+                arr[i] = (char*)PyUnicode_2BYTE_DATA(PyList_GetItem($input, i));
+            }
+            else if (kind == PyUnicode_4BYTE_KIND) {
+                arr[i] = (char*)PyUnicode_4BYTE_DATA(PyList_GetItem($input, i));
+            }
+            else {
+                //for 3.11 and under since its deprecated
+                arr[i] = (char*)PyUnicode_AS_DATA(PyList_GetItem($input, i));
+            }
         }
     #endif
         else {
@@ -450,11 +463,25 @@ namespace pdftron {
         }
         if (PyUnicode_Check($str)) {
             // Ensure String only contains 1 character
-            if (PyUnicode_GET_SIZE($str) != 1) {
+            if (PyUnicode_GET_LENGTH($str) != 1) {
                 PyErr_SetString(PyExc_ValueError,"Only one character allowed per list item");
                 return NULL;
             }
-            char* $temp1 = (char*)PyUnicode_AS_DATA($str);
+            int kind = PyUnicode_KIND(PyList_GetItem($input, i))
+            char* $temp1 = 0;
+            if (kind == (int)PyUnicode_1BYTE_KIND) {
+                char* $temp1 = (char*)PyUnicode_1BYTE_DATA($str);
+            }
+            else if (kind == (int)PyUnicode_2BYTE_KIND) {
+                char* $temp1 = (char*)PyUnicode_2BYTE_DATA($str);
+            }
+            else if (kind == (int)PyUnicode_4BYTE_KIND) {
+                char* $temp1 = (char*)PyUnicode_4BYTE_DATA($str);
+            }
+            else {
+                //for 3.11 and under since its deprecated
+                char* $temp1 = (char*)PyUnicode_AS_DATA($str);
+            }
             $temp[i] = (pdftron::Unicode)*$temp1;
         }
         else {

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -463,19 +463,19 @@ namespace pdftron {
                 PyErr_SetString(PyExc_ValueError,"Only one character allowed per list item");
                 return NULL;
             }
-            int kind = PyUnicode_KIND(PyList_GetItem($input, i));
-            char* $temp1 = 0;
+            int kind = PyUnicode_KIND($str);
             if (kind == (int)PyUnicode_1BYTE_KIND) {
                 char* $temp1 = (char*)PyUnicode_1BYTE_DATA($str);
+                $temp[i] = (pdftron::Unicode)*$temp1;
             }
             else if (kind == (int)PyUnicode_2BYTE_KIND) {
                 char* $temp1 = (char*)PyUnicode_2BYTE_DATA($str);
+                $temp[i] = (pdftron::Unicode)*$temp1;
             }
             else if (kind == (int)PyUnicode_4BYTE_KIND) {
                 char* $temp1 = (char*)PyUnicode_4BYTE_DATA($str);
+                $temp[i] = (pdftron::Unicode)*$temp1;
             }
-
-            $temp[i] = (pdftron::Unicode)*$temp1;
         }
         else {
             $temp[i] = (pdftron::Unicode)PyInt_AsLong($str);


### PR DESCRIPTION
code changes:
-Replace the removed method & property on 3.12 to the recommended methods based on the api docs below
(https://docs.python.org/3.11/c-api/unicode.html)