### PR TITLE
Modify PHP samples so that it can work with PHP8

### DIFF
--- a/Samples/AnnotationTest/PHP/AnnotationTest.php
+++ b/Samples/AnnotationTest/PHP/AnnotationTest.php
@@ -121,7 +121,8 @@ function AnnotationHighLevelAPI($doc) {
 }
 
 function AnnotationLowLevelAPI($doc) {
-	$page = $doc->GetPageIterator()->Current();
+	$ir = $doc->GetPageIterator();
+	$page = $ir->Current();
 	$annots = $page->GetAnnots();
 
 	if (!$annots)

--- a/Samples/BookmarkTest/PHP/BookmarkTest.php
+++ b/Samples/BookmarkTest/PHP/BookmarkTest.php
@@ -57,9 +57,6 @@ function PrintOutlineTree($item) {
 	$input_path = getcwd()."/../../TestFiles/";
 	$output_path = $input_path."Output/";
 
-	$doc = new PDFDoc($input_path."numbered.pdf");
-	$doc->InitSecurityHandler();
-
 	// The following example illustrates how to create and edit the outline tree 
 	// using high-level Bookmark methods.
 	$doc = new PDFDoc($input_path."numbered.pdf");
@@ -82,7 +79,8 @@ function PrintOutlineTree($item) {
 
 	// The following example creates an 'explicit' destination (see 
 	// section '8.2.1 Destinations' in PDF Reference for more details)
-	$red_dest = Destination::CreateFit($doc->GetPageIterator()->Current());
+	$ir= $doc->GetPageIterator();
+	$red_dest = Destination::CreateFit($ir->Current());
 	$red->SetAction(Action::CreateGoto($red_dest));
 
 	// Create an explicit destination to the first green page in the document

--- a/Samples/ElementReaderAdvTest/PHP/ElementReaderAdvTest.php
+++ b/Samples/ElementReaderAdvTest/PHP/ElementReaderAdvTest.php
@@ -19,7 +19,7 @@ function ProcessPath($reader, $path)
 	$opr = $pathData->GetOperators();
 
 	$opr_index = 0;
-	$opr_end = count($opr);
+	$opr_end = count((array)$opr);
 	$data_index = 0;
 	$data_end = count($data);
 

--- a/Samples/OfficeTemplateTest/PHP/OfficeTemplateTest.php
+++ b/Samples/OfficeTemplateTest/PHP/OfficeTemplateTest.php
@@ -58,7 +58,7 @@ function main()
 	$pdfdoc = $template_doc->FillTemplateJson($json);
 
 	// Save the PDF to a file.
-	$pdfdoc->Save($output_path.$output_filename, SDFDoc::e_linearized, NULL);
+	$pdfdoc->Save($output_path.$output_filename, SDFDoc::e_linearized);
 
 	// And we're done!
 	echo nl2br("Saved ".$output_filename . "\n");

--- a/Samples/PDFDrawTest/PHP/PDFDrawTest.php
+++ b/Samples/PDFDrawTest/PHP/PDFDrawTest.php
@@ -43,7 +43,6 @@ $output_path = $input_path."Output/";
 	// PDFNet::AddFontSubst(PDFNet::e_Korea1, "AdobeMyungjoStd-Medium.otf");
 	// PDFNet::AddFontSubst(PDFNet::e_CNS1, "AdobeSongStd-Light.otf");
 	// PDFNet::AddFontSubst(PDFNet::e_GB1, "AdobeMingStd-Light.otf");
-	
 	$draw = new PDFDraw();
 
 	//--------------------------------------------------------------------------------
@@ -60,12 +59,13 @@ $output_path = $input_path."Output/";
 	$draw->SetDPI(92);
 
 	// C) Rasterize the first page in the document and save the result as PNG.
-	$draw->Export($doc->GetPageIterator()->Current(), $output_path."tiger_92dpi.png");
+	$ir = $doc->GetPageIterator();
+	$draw->Export($ir->Current(), $output_path."tiger_92dpi.png");
 
 	echo nl2br("Example 1: tiger_92dpi.png\n");
 
 	// Export the same page as TIFF
-	$draw->Export($doc->GetPageIterator()->Current(), $output_path."tiger_92dpi.tif", "TIFF");
+	$draw->Export($ir->Current(), $output_path."tiger_92dpi.tif", "TIFF");
 
 	//--------------------------------------------------------------------------------
 	// Example 2) Convert the all pages in a given document to JPEG at 72 DPI.
@@ -229,17 +229,18 @@ $output_path = $input_path."Output/";
 
 	$draw->SetImageSmoothing(false, false);
 	$filename = "raster_text_no_smoothing.png";
-	$draw->Export($text_doc->GetPageIterator()->Current(), $output_path.$filename);
+	$ir = $text_doc->GetPageIterator();
+	$draw->Export($ir->Current(), $output_path.$filename);
 	echo nl2br("Example 9 a): ".$filename.". Done.\n");
 
 	$filename = "raster_text_smoothed.png";
 	$draw->SetImageSmoothing(true, false /*default quality bilinear resampling*/);
-	$draw->Export($text_doc->GetPageIterator()->Current(), $output_path.$filename);
+	$draw->Export($ir->Current(), $output_path.$filename);
 	echo nl2br("Example 9 b): ".$filename.". Done.\n");
 
 	$filename = "raster_text_high_quality.png";
 	$draw->SetImageSmoothing(true, true /*high quality area resampling*/);
-	$draw->Export($text_doc->GetPageIterator()->Current(), $output_path.$filename);
+	$draw->Export($ir->Current(), $output_path.$filename);
 	echo nl2br("Example 9 c): ".$filename.". Done.\n");
 
 	//--------------------------------------------------------------------------------
@@ -253,15 +254,16 @@ $output_path = $input_path."Output/";
 	$draw->SetOverprint(PDFRasterizer::e_op_on);
 
 	$filename = "merged_separations.png";
-	$draw->Export($separation_doc->GetPageIterator()->Current(), $output_path.$filename, "PNG");
+	$ir = $separation_doc->GetPageIterator();
+	$draw->Export($ir->Current(), $output_path.$filename, "PNG");
 	echo nl2br("Example 10 a): ".$filename.". Done.\n");
 
 	$filename = "separation";
-	$draw->Export($separation_doc->GetPageIterator()->Current(), $output_path.$filename, "PNG", $separation_hint);
+	$draw->Export($ir->Current(), $output_path.$filename, "PNG", $separation_hint);
 	echo nl2br("Example 10 b): ".$filename."_[ink].png. Done.\n");
 
 	$filename = "separation_NChannel.tif";
-	$draw->Export($separation_doc->GetPageIterator()->Current(), $output_path.$filename, "TIFF", $separation_hint);
+	$draw->Export($ir->Current(), $output_path.$filename, "TIFF", $separation_hint);
 	echo nl2br("Example 10 c): ".$filename.". Done.\n");
 	PDFNet::Terminate();
 ?>


### PR DESCRIPTION
Errored out samples have been modified so it works

for ElementReaderAdvTest:
PHP8 basically has new rule that makes the old code doesn't work anymore (On PHP8.0 compulsory types are define on Count.) Type array has to be casted 

for OfficeTemplateTest:
other samples are using 2 parameters for pdfdoc->Save but PHP was using 3, so I just changed it to 2

for the others (PDFDrawTest, AnnotationTest, Bookmark)
All the objects that were throwing error were because they were direct objects. Following Python sample by creating new variables to store those objects prevent the errors
