### PR TITLE
Adding better error handling in Go through panic/recovery method with error returns

### DIFF
--- a/PDFTronGo/pdftron.i
+++ b/PDFTronGo/pdftron.i
@@ -233,32 +233,6 @@
     }
 }
 
-// Exclude director classes from exception handling typemaps
-%typemap(gotype) pdftron::PDF::Callback* "$gotype"
-%typemap(goout) pdftron::PDF::Callback* %{
-    return $cgocall
-%}
-
-%typemap(gotype) pdftron::SDF::SignatureHandler* "$gotype"
-%typemap(goout) pdftron::SDF::SignatureHandler* %{
-    return $cgocall
-%}
-
-%typemap(gotype) pdftron::PDF::Separation* "$gotype"
-%typemap(goout) pdftron::PDF::Separation* %{
-    return $cgocall
-%}
-
-%typemap(gotype) pdftron::PDF::Rect* "$gotype"
-%typemap(goout) pdftron::PDF::Rect* %{
-    return $cgocall
-%}
-
-%typemap(gotype) pdftron::PDF::Date* "$gotype"
-%typemap(goout) pdftron::PDF::Date* %{
-    return $cgocall
-%}
-
 // Macro for generating gotype (adding error to return) and goout (adding panic recovery to return errors) typemaps
 %define EXCEPTION_HANDLING_TYPEMAP(TYPE)
 %typemap(gotype) TYPE "$gotype, error"


### PR DESCRIPTION
This PR is a WIP to change how we handle errors in our Go SDK. Previously, we just panicked on every error. However, errors in Go are normally returned in addition to other return types. This PR bridges the gap between C++ exceptions and Go errors using typemaps in SWIG. However, it is a WIP as these typemaps have been causing issues with SWIG's internal functions when applied broadly.