### PR TITLE
Made ICR sample leaner and faster (#208)

### DIFF
--- a/Samples/HandwritingICRTest/GO/HandwritingICR_test.go
+++ b/Samples/HandwritingICRTest/GO/HandwritingICR_test.go
@@ -83,6 +83,7 @@ func TestHandwritingICR(t *testing.T) {
 		doc.Close()
 
 		// --------------------------------------------------------------------------------
+/*
 		// Example 2) Process a subset of PDF pages
 		fmt.Println("Example 2: processing pages from icr.pdf")
 
@@ -93,7 +94,7 @@ func TestHandwritingICR(t *testing.T) {
 		options := NewHandwritingICROptions()
 		
 		// Optionally, process a subset of pages
-		options.SetPages("2-3")
+		options.SetPages("1-3")
 
 		// Run ICR on the .pdf
 		HandwritingICRModuleProcessPDF(doc, options)
@@ -101,6 +102,7 @@ func TestHandwritingICR(t *testing.T) {
 		// Save the result with hidden text applied
 		doc.Save(outputPath + "icr-pages.pdf", uint(SDFDocE_linearized))
 		doc.Close()
+*/
 
 		// --------------------------------------------------------------------------------
 		// Example 3) Ignore zones specified for each page
@@ -110,15 +112,14 @@ func TestHandwritingICR(t *testing.T) {
 		doc = NewPDFDoc(inputPath + "icr.pdf")
 		
 		// Process handwriting with custom options
-		options = NewHandwritingICROptions()
+		options := NewHandwritingICROptions()
 		
-		// Process page 2 by ignoring the signature area on the bottom
-		options.SetPages("2")
-		ignoreZonesPage2 := NewRectCollection()
+		// Process page 1 by ignoring the signature area on the bottom
+		ignoreZonesPage1 := NewRectCollection()
 		// These coordinates are in PDF user space, with the origin at the bottom left corner of the page.
 		// Coordinates rotate with the page, if it has rotation applied.
-		ignoreZonesPage2.AddRect(NewRect(78.0, 850.1 - 770.0, 340.0, 850.1 - 676.0))
-		options.AddIgnoreZonesForPage(ignoreZonesPage2, 2)
+		ignoreZonesPage1.AddRect(NewRect(78.0, 850.1 - 770.0, 340.0, 850.1 - 676.0))
+		options.AddIgnoreZonesForPage(ignoreZonesPage1, 1)
 
 		// Run ICR on the .pdf
 		HandwritingICRModuleProcessPDF(doc, options)

--- a/Samples/HandwritingICRTest/PHP/HandwritingICRTest.php
+++ b/Samples/HandwritingICRTest/PHP/HandwritingICRTest.php
@@ -60,6 +60,7 @@ function WriteTextToFile($outputFile, $text)
 		$doc->Close();
 
 		//--------------------------------------------------------------------------------
+/*
 		// Example 2) Process a subset of PDF pages
 		echo "Example 2: processing pages from icr.pdf\n";
 	 
@@ -70,7 +71,7 @@ function WriteTextToFile($outputFile, $text)
 		$options = new HandwritingICROptions();
 		
 		// Optionally, process a subset of pages
-		$options->SetPages("2-3");
+		$options->SetPages("1-3");
 
 		// Run ICR on the .pdf
 		HandwritingICRModule::ProcessPDF($doc, $options);
@@ -78,6 +79,7 @@ function WriteTextToFile($outputFile, $text)
 		// Save the result with hidden text applied
 		$doc->Save($output_path."icr-pages.pdf", SDFDoc::e_linearized);
 		$doc->Close();
+*/
 
 		//--------------------------------------------------------------------------------
 		// Example 3) Ignore zones specified for each page
@@ -89,14 +91,13 @@ function WriteTextToFile($outputFile, $text)
 		// Process handwriting with custom options
 		$options = new HandwritingICROptions();
 		
-		// Process page 2 by ignoring the signature area on the bottom
-		$options->SetPages("2");
-		$ignore_zones_page2 = new RectCollection();
+		// Process page 1 by ignoring the signature area on the bottom
+		$ignore_zones_page1 = new RectCollection();
 		// These coordinates are in PDF user space, with the origin at the bottom left corner of the page.
 		// Coordinates rotate with the page, if it has rotation applied.
 		$rect = new Rect(78.0, 850.1 - 770.0, 340.0, 850.1 - 676.0);
-		$ignore_zones_page2->AddRect($rect);
-		$options->AddIgnoreZonesForPage($ignore_zones_page2, 2);
+		$ignore_zones_page1->AddRect($rect);
+		$options->AddIgnoreZonesForPage($ignore_zones_page1, 1);
 
 		// Run ICR on the .pdf
 		HandwritingICRModule::ProcessPDF($doc, $options);

--- a/Samples/HandwritingICRTest/PYTHON/HandwritingICRTest.py
+++ b/Samples/HandwritingICRTest/PYTHON/HandwritingICRTest.py
@@ -68,25 +68,25 @@ def main():
         doc.Save(output_path + "icr-simple.pdf", SDFDoc.e_linearized)
         doc.Close()
 
-        # --------------------------------------------------------------------------------
-        # Example 2) Process a subset of PDF pages
-        print("Example 2: processing pages from icr.pdf")
-
-        # Open the .pdf document
-        doc = PDFDoc(input_path + "icr.pdf")
-
-        # Process handwriting with custom options
-        options = HandwritingICROptions()
-        
-        # Optionally, process a subset of pages
-        options.SetPages("2-3")
-
-        # Run ICR on the .pdf
-        HandwritingICRModule.ProcessPDF(doc, options)
-
-        # Save the result with hidden text applied
-        doc.Save(output_path + "icr-pages.pdf", SDFDoc.e_linearized)
-        doc.Close()
+#       # --------------------------------------------------------------------------------
+#       # Example 2) Process a subset of PDF pages
+#       print("Example 2: processing pages from icr.pdf")
+#
+#       # Open the .pdf document
+#       doc = PDFDoc(input_path + "icr.pdf")
+#
+#       # Process handwriting with custom options
+#       options = HandwritingICROptions()
+#
+#       # Optionally, process a subset of pages
+#       options.SetPages("1-3")
+#
+#       # Run ICR on the .pdf
+#       HandwritingICRModule.ProcessPDF(doc, options)
+#
+#       # Save the result with hidden text applied
+#       doc.Save(output_path + "icr-pages.pdf", SDFDoc.e_linearized)
+#       doc.Close()
 
         # --------------------------------------------------------------------------------
         # Example 3) Ignore zones specified for each page
@@ -98,13 +98,12 @@ def main():
         # Process handwriting with custom options
         options = HandwritingICROptions()
         
-        # Process page 2 by ignoring the signature area on the bottom
-        options.SetPages("2")
-        ignore_zones_page2 = RectCollection()
+        # Process page 1 by ignoring the signature area on the bottom
+        ignore_zones_page1 = RectCollection()
         # These coordinates are in PDF user space, with the origin at the bottom left corner of the page.
         # Coordinates rotate with the page, if it has rotation applied.
-        ignore_zones_page2.AddRect(Rect(78, 850.1 - 770, 340, 850.1 - 676))
-        options.AddIgnoreZonesForPage(ignore_zones_page2, 2)
+        ignore_zones_page1.AddRect(Rect(78, 850.1 - 770, 340, 850.1 - 676))
+        options.AddIgnoreZonesForPage(ignore_zones_page1, 1)
 
         # Run ICR on the .pdf
         HandwritingICRModule.ProcessPDF(doc, options)

--- a/Samples/HandwritingICRTest/RUBY/HandwritingICRTest.rb
+++ b/Samples/HandwritingICRTest/RUBY/HandwritingICRTest.rb
@@ -56,25 +56,25 @@ begin
 		doc.Save($output_path + "icr-simple.pdf", SDFDoc::E_linearized)
 		doc.Close
 
-		# --------------------------------------------------------------------------------
-		# Example 2) Process a subset of PDF pages
-		puts "Example 2: processing pages from icr.pdf"
-
-		# Open the .pdf document
-		doc = PDFDoc.new($input_path + "icr.pdf")
-
-		# Process handwriting with custom options
-		options = HandwritingICROptions.new
-
-		# Optionally, process a subset of pages
-		options.SetPages("2-3")
-
-		# Run ICR on the .pdf
-		HandwritingICRModule.ProcessPDF(doc, options)
-
-		# Save the result with hidden text applied
-		doc.Save($output_path + "icr-pages.pdf", SDFDoc::E_linearized)
-		doc.Close
+#		# --------------------------------------------------------------------------------
+#		# Example 2) Process a subset of PDF pages
+#		puts "Example 2: processing pages from icr.pdf"
+#
+#		# Open the .pdf document
+#		doc = PDFDoc.new($input_path + "icr.pdf")
+#
+#		# Process handwriting with custom options
+#		options = HandwritingICROptions.new
+#
+#		# Optionally, process a subset of pages
+#		options.SetPages("1-3")
+#
+#		# Run ICR on the .pdf
+#		HandwritingICRModule.ProcessPDF(doc, options)
+#
+#		# Save the result with hidden text applied
+#		doc.Save($output_path + "icr-pages.pdf", SDFDoc::E_linearized)
+#		doc.Close
 
 		# --------------------------------------------------------------------------------
 		# Example 3) Ignore zones specified for each page
@@ -86,13 +86,12 @@ begin
 		# Process handwriting with custom options
 		options = HandwritingICROptions.new
 
-		# Process page 2 by ignoring the signature area on the bottom
-		options.SetPages("2")
-		ignore_zones_page2 = RectCollection.new
+		# Process page 1 by ignoring the signature area on the bottom
+		ignore_zones_page1 = RectCollection.new
 		# These coordinates are in PDF user space, with the origin at the bottom left corner of the page.
 		# Coordinates rotate with the page, if it has rotation applied.
-		ignore_zones_page2.AddRect(Rect.new(78, 850.1 - 770, 340, 850.1 - 676))
-		options.AddIgnoreZonesForPage(ignore_zones_page2, 2)
+		ignore_zones_page1.AddRect(Rect.new(78, 850.1 - 770, 340, 850.1 - 676))
+		options.AddIgnoreZonesForPage(ignore_zones_page1, 1)
 
 		# Run ICR on the .pdf
 		HandwritingICRModule.ProcessPDF(doc, options)


### PR DESCRIPTION
### Summary

Cherry-pick from https://github.com/ApryseSDK/PDFNetWrappers/pull/208

Made the ICR sample leaner and faster.

### Context/Why?

The ICR is very slow. The sample is now just a single page, and one of the code samples is commented out.

### Implementation notes

### How to verify

Run HandwritingICRTest.

### Changelog entry

N/A