### PR TITLE
Fix extra PDFDoc() events in SWIG wrappers

### DIFF
--- a/PDFNetPHP/PDFNetPHP.i
+++ b/PDFNetPHP/PDFNetPHP.i
@@ -851,6 +851,10 @@ namespace pdftron {
     }
 }
 
+// Value Wrappers prevent excessive item creation by wrapping the item in SwigValueWrapper
+%feature("valuewrapper") pdftron::PDF::PDFDoc;
+
+
 //----------------------------------------------------------------------------------------------
 /**
  * Typemap for function pointers

--- a/PDFNetPython/PDFNetPython.i
+++ b/PDFNetPython/PDFNetPython.i
@@ -719,6 +719,10 @@ namespace pdftron {
     }
 }
 
+// Value Wrappers prevent excessive item creation by wrapping the item in SwigValueWrapper
+%feature("valuewrapper") pdftron::PDF::PDFDoc;
+
+
 //----------------------------------------------------------------------------------------------
 /**
  * Typemap for function pointers

--- a/PDFTronGo/pdftron.i
+++ b/PDFTronGo/pdftron.i
@@ -306,6 +306,9 @@ namespace pdftron {
     }
 }
 
+// Value Wrappers prevent excessive item creation by wrapping the item in SwigValueWrapper
+%feature("valuewrapper") pdftron::PDF::PDFDoc;
+
 /**
  * Turns on the director feature for the following classes.
  * C++ equivalent of a proxy class. User extends this class in GOLang


### PR DESCRIPTION
### Summary

Port changes from PR #180


### Context/Why?

Previous PR only handled Ruby, but it appears to have correctly fixed it.
We're now porting over the fix to the other SWIG languages

### Implementation notes

<!--
What approach was used?
Any key decisions or trade-offs to mention?
Were any alternatives considered?
-->

### How to verify

- Using PWSTester:
  - latest PWSTester requires the ScopeBegin/End changes from sch/ftr-3165
  - either rebase them onto master or build directly from this branch
  - after running, check test_output/stats/per_api_report and compare with previous

https://jenkins.apryse.com/job/apryse-sdk/job/apryse-sdk-go-windows/view/change-requests/job/PR-212/
https://jenkins.apryse.com/job/apryse-sdk/job/apryse-sdk-ruby-alpine/view/change-requests/job/PR-6432/
https://jenkins.apryse.com/job/apryse-sdk/job/apryse-sdk-php-linux/view/change-requests/job/PR-6432/
https://jenkins.apryse.com/job/apryse-sdk/job/apryse-sdk-py3-windows/view/change-requests/job/PR-6432/

### Changelog entry

N/A
